### PR TITLE
remove background-color

### DIFF
--- a/src/modbus-flex-getter.html
+++ b/src/modbus-flex-getter.html
@@ -66,7 +66,7 @@
 
 <script type="text/x-red" data-template-name="modbus-flex-getter">
     <div class="form-row">
-        <ul style="background: #fff; min-width: 600px; margin-bottom: 20px;" id="node-input-modbus-tabs"></ul>
+        <ul style="min-width: 600px; margin-bottom: 20px;" id="node-input-modbus-tabs"></ul>
     </div>
     <div id="node-input-tabs-content" style="min-height: 170px;">
         <div id="modbus-settings-tab" style="display:none">


### PR DESCRIPTION
The element style prevents styling by other themes and should be removed.