### PR TITLE
Fix server restart on socket error

### DIFF
--- a/src/modbus-flex-server.js
+++ b/src/modbus-flex-server.js
@@ -96,11 +96,11 @@ module.exports = function (RED) {
             if (node.showErrors) {
               node.warn(err)
             }
-            mbBasics.setNodeStatusTo('error', node)
+            /*mbBasics.setNodeStatusTo('error', node)
 
             node.modbusServer.close(function () {
               node.startServer()
-            })
+            })*/
           })
 
           node.modbusServer._server.on('connection', function (sock) {


### PR DESCRIPTION
The server should not need to restart because of a socket error