### PR TITLE
Fix Bug after restart of Modbus-flex-server with active modbus-tcp connection Update modbus-flex-server.js

### DIFF
--- a/src/modbus-flex-server.js
+++ b/src/modbus-flex-server.js
@@ -165,6 +165,9 @@ module.exports = function (RED) {
       if (node.modbusServer._server) {
         node.modbusServer._server.close()
       }
+     if(node.modbusServer){
+        node.modbusServer.close();
+      }
       node.modbusServer = null
     })
   }


### PR DESCRIPTION
Fix Bug after restart of Modbus-flex-server with active modbus-tcp connection
Issues Detail
https://github.com/BiancoRoyal/node-red-contrib-modbus/issues/224