### PR TITLE
Add check for err.code on tcp error handling

### DIFF
--- a/examples/Modbus-Flex-Suite.json
+++ b/examples/Modbus-Flex-Suite.json
@@ -1477,7 +1477,8 @@
     "unit_id": 1,
     "commandDelay": 1,
     "clientTimeout": 1000,
-    "reconnectTimeout": 2000
+    "reconnectDelay": 2000,
+    "connectionTimeout": 10000
   },
   {
     "id": "883d0976.8296d",
@@ -1500,6 +1501,7 @@
     "unit_id": "1",
     "commandDelay": "1",
     "clientTimeout": "1000",
-    "reconnectTimeout": "2000"
+    "reconnectDelay": "2000",
+    "connectionTimeout": "10000"
   }
 ]

--- a/examples/Modbus-HTTP.json
+++ b/examples/Modbus-HTTP.json
@@ -703,7 +703,8 @@
     "commandDelay": "1",
     "clientTimeout": "1000",
     "reconnectOnTimeout": true,
-    "reconnectTimeout": "2000",
-    "parallelUnitIdsAllowed": true
+    "reconnectDelay": "2000",
+    "parallelUnitIdsAllowed": true,
+    "connectionTimeout": "10000"
   }
 ]

--- a/examples/Modbus-Read-Write-Servers.json
+++ b/examples/Modbus-Read-Write-Servers.json
@@ -914,8 +914,9 @@
     "commandDelay": "1",
     "clientTimeout": "1000",
     "reconnectOnTimeout": true,
-    "reconnectTimeout": "2000",
-    "parallelUnitIdsAllowed": true
+    "reconnectDelay": "2000",
+    "parallelUnitIdsAllowed": true,
+    "connectionTimeout": "10000"
   },
   {
     "id": "aefcd568.ff81c",
@@ -940,7 +941,8 @@
     "commandDelay": "1",
     "clientTimeout": "1000",
     "reconnectOnTimeout": true,
-    "reconnectTimeout": "2000",
-    "parallelUnitIdsAllowed": true
+    "reconnectDelay": "2000",
+    "parallelUnitIdsAllowed": true,
+    "connectionTimeout": "10000"
   }
 ]

--- a/examples/Modbus-Slave.json
+++ b/examples/Modbus-Slave.json
@@ -604,6 +604,7 @@
         "unit_id": "1",
         "commandDelay": "1",
         "clientTimeout": "1000",
-        "reconnectTimeout": "2000"
+        "reconnectDelay": "2000",
+        "connectionTimeout": "10000"
     }
 ]

--- a/examples/Multiple-Dynamic-FunctionCodes.json
+++ b/examples/Multiple-Dynamic-FunctionCodes.json
@@ -320,7 +320,8 @@
     "unit_id": "1",
     "commandDelay": "1",
     "clientTimeout": "1000",
-    "reconnectTimeout": "2000"
+    "reconnectDelay": "2000",
+    "connectionTimeout": "10000"
   },
   {
     "id": "d789f1bb.d6ea18",
@@ -343,6 +344,7 @@
     "unit_id": "1",
     "commandDelay": "1",
     "clientTimeout": "1000",
-    "reconnectTimeout": "2000"
+    "reconnectDelay": "2000",
+    "connectionTimeout": "10000"
   }
 ]

--- a/examples/Simple-Modbus-Demo.json
+++ b/examples/Simple-Modbus-Demo.json
@@ -56,8 +56,9 @@
     "commandDelay": 1,
     "clientTimeout": 1000,
     "reconnectOnTimeout": true,
-    "reconnectTimeout": 2000,
-    "parallelUnitIdsAllowed": true
+    "reconnectDelay": 2000,
+    "parallelUnitIdsAllowed": true,
+    "connectionTimeout": 10000
   },
   {
     "id": "352955bb.be6e6a",
@@ -81,8 +82,9 @@
     "commandDelay": "1",
     "clientTimeout": "1000",
     "reconnectOnTimeout": true,
-    "reconnectTimeout": "2000",
-    "parallelUnitIdsAllowed": true
+    "reconnectDelay": "2000",
+    "parallelUnitIdsAllowed": true,
+    "connectionTimeout": "10000"
   },
   {
     "id": "7dd49c19.29e75c",

--- a/examples/modbus-switch-tcp.json
+++ b/examples/modbus-switch-tcp.json
@@ -653,7 +653,8 @@
     "commandDelay": "1",
     "clientTimeout": "1000",
     "reconnectOnTimeout": true,
-    "reconnectTimeout": "2000",
-    "parallelUnitIdsAllowed": true
+    "reconnectDelay": "2000",
+    "parallelUnitIdsAllowed": true,
+    "connectionTimeout": "10000"
   }
 ]

--- a/src/core/modbus-client-core.js
+++ b/src/core/modbus-client-core.js
@@ -410,8 +410,12 @@ de.biancoroyal.modbus.core.client.setNewNodeOptionalSettings = function (node, m
     node.clientTimeout = parseInt(msg.payload.clientTimeout) || node.clientTimeout
   }
 
-  if (msg.payload.reconnectTimeout) {
-    node.reconnectTimeout = parseInt(msg.payload.reconnectTimeout) || node.reconnectTimeout
+  if (msg.payload.reconnectDelay) {
+    node.reconnectDelay = parseInt(msg.payload.reconnectDelay) || node.reconnectDelay
+  }
+
+  if (msg.payload.connectionTimeout) {
+    node.connectionTimeout = parseInt(msg.payload.connectionTimeout) || node.connectionTimeout
   }
 }
 

--- a/src/locales/de-DE/modbus-client.json
+++ b/src/locales/de-DE/modbus-client.json
@@ -19,7 +19,8 @@
       "commandDelay": "Queue Sendeverzögerung (ms)",
       "timeout": "Timeout (ms)",
       "reconnectOnTimeout": "Reconnect bei Timeouts",
-      "reconnectTimeout": "Reconnect-Timeout (ms)"
+      "reconnectDelay": "Reconnect-Delay (ms)",
+      "connectionTimeout": "Connection Timeout (ms)"
     }
   }
 }

--- a/src/locales/en-US/modbus-client.json
+++ b/src/locales/en-US/modbus-client.json
@@ -20,8 +20,9 @@
       "commandDelay": "Queue delay (ms)",
       "timeout": "Timeout (ms)",
       "reconnectOnTimeout": "Reconnect on timeout",
-      "reconnectTimeout": "Reconnect timeout (ms)",
-      "parallelUnitIdsAllowed": "UnitId's in parallel"
+      "reconnectDelay": "Reconnect delay (ms)",
+      "parallelUnitIdsAllowed": "UnitId's in parallel",
+      "connectionTimeout": "Connection timeout (ms)"
     }
   }
 }

--- a/src/modbus-basics.js
+++ b/src/modbus-basics.js
@@ -262,7 +262,7 @@ de.biancoroyal.modbus.basics.onModbusQueue = function (node) {
 }
 
 de.biancoroyal.modbus.basics.onModbusBroken = function (node, modbusClient) {
-  this.setNodeStatusTo('reconnecting after ' + modbusClient.reconnectTimeout + ' msec.', node)
+  this.setNodeStatusTo('reconnecting after ' + modbusClient.reconnectDelay + ' msec.', node)
 }
 
 de.biancoroyal.modbus.basics.setNodeDefaultStatus = function (node) {

--- a/src/modbus-client.html
+++ b/src/modbus-client.html
@@ -34,7 +34,8 @@
       commandDelay: {value: 1},
       clientTimeout: {value: 1000},
       reconnectOnTimeout: {value: true},
-      reconnectTimeout: {value: 2000},
+      reconnectDelay: {value: 2000},
+      connectionTimeout: {value: 10000},
       parallelUnitIdsAllowed: {value: true}
     },
     label: function () {
@@ -75,8 +76,12 @@
           node.clientTimeout = parseInt(node.clientTimeout)
         }
 
-        if (node.reconnectTimeout) {
-          node.reconnectTimeout = parseInt(node.reconnectTimeout)
+        if (node.reconnectDelay) {
+          node.reconnectDelay = parseInt(node.reconnectDelay)
+        }
+
+        if (node.connectionTimeout) {
+          node.connectionTimeout = parseInt(node.connectionTimeout)
         }
 
         switch (clientTypeSelector.val()) {
@@ -211,6 +216,13 @@
                 <option value="C701">C701</option>
             </select>
         </div>
+        <div class="form-row">
+          <label for="node-config-input-connectionTimeout">
+              <i class="icon-time"></i>
+              <span data-i18n="modbus-contrib.label.connectionTimeout"></span>
+          </label>
+          <input type="text" id="node-config-input-connectionTimeout" placeholder="10000" style="max-width:80px">
+        </div>
     </div>
     <div id="node-inputs-modbus-serial">
         <div class="form-row">
@@ -294,11 +306,11 @@
         <input type="checkbox" id="node-config-input-reconnectOnTimeout" style="max-width:30px">
     </div>
     <div class="form-row">
-        <label for="node-config-input-reconnectTimeout">
+        <label for="node-config-input-reconnectDelay">
             <i class="icon-time"></i>
-            <span data-i18n="modbus-contrib.label.reconnectTimeout"></span>
+            <span data-i18n="modbus-contrib.label.reconnectDelay"></span>
         </label>
-        <input type="text" id="node-config-input-reconnectTimeout" placeholder="2000" style="max-width:80px">
+        <input type="text" id="node-config-input-reconnectDelay" placeholder="2000" style="max-width:80px">
     </div>
     <div class="form-row">
         <label style="min-width:160px" for="node-config-input-parallelUnitIdsAllowed"><i class="fa fa-th"></i> <span
@@ -362,7 +374,7 @@
             <li>Unit-ID (default 1 [serial] or 0 [tcp]) - to set one Unit-ID for all nodes without Unit-ID.
             Set the Unit-ID of the Read/Write/Getter node's to empty for using this ID</li>
             <li>Timeout (default 1000 ms) - ms for the command timeout on ModbusRTU command</li>
-            <li>Reconnect timeout (default 2000 ms) - time to wait on reconnect before next sending</li>
+            <li>Reconnect delay (default 2000 ms) - time to wait on reconnect before next sending</li>
             <li>Reconnect on timeout - should the client do a reconnect or not on timeouts</li>
             <li>Parallel UnitId's allowed - handle commands in parallel per UnitId or not</li>
         </ul>
@@ -371,6 +383,8 @@
         <ul>
             <li>Host - IP address</li>
             <li>Port (default 502)</li>
+            <li>Connection timeout (default 10000 ms) - time to wait before aborting a connection attempt</li>
+            
         </ul>
 
         <h3>Serial</h3>

--- a/src/modbus-flex-connector.html
+++ b/src/modbus-flex-connector.html
@@ -83,7 +83,8 @@
             <li>msg.payload.unitId || node.unit_id
             <li>msg.payload.commandDelay || node.commandDelay
             <li>msg.payload.clientTimeout || node.clientTimeout
-            <li>msg.payload.reconnectTimeout| || node.reconnectTimeout
+            <li>msg.payload.reconnectDelay| || node.reconnectDelay
+            <li>msg.payload.connectionTimeout| || node.connectionTimeout
         </ul>
     </p>
 
@@ -101,7 +102,8 @@
           <li>msg.payload.unitId || node.unit_id
           <li>msg.payload.commandDelay || node.commandDelay
           <li>msg.payload.clientTimeout || node.clientTimeout
-          <li>msg.payload.reconnectTimeout || node.reconnectTimeout
+          <li>msg.payload.reconnectDelay || node.reconnectDelay
+          <li>msg.payload.connectionTimeout || node.connectionTimeout
         </ul>
     </p>
 

--- a/src/modbus-read.js
+++ b/src/modbus-read.js
@@ -121,7 +121,7 @@ module.exports = function (RED) {
     node.onModbusBroken = function () {
       setNodeStatusWithTimeTo('broken')
       if (modbusClient.reconnectOnTimeout) {
-        setNodeStatusWithTimeTo('reconnecting after ' + modbusClient.reconnectTimeout + ' msec.')
+        setNodeStatusWithTimeTo('reconnecting after ' + modbusClient.reconnectDelay + ' msec.')
         node.resetAllReadingTimer()
       }
     }

--- a/test/integration/modbus-read-integration-test.js
+++ b/test/integration/modbus-read-integration-test.js
@@ -108,8 +108,9 @@ const testFlowReading = [
     commandDelay: '1',
     clientTimeout: '1000',
     reconnectOnTimeout: true,
-    reconnectTimeout: 200,
-    parallelUnitIdsAllowed: true
+    reconnectDelay: 200,
+    parallelUnitIdsAllowed: true,
+    connectionTimeout: 10000
   }
 ]
 

--- a/test/integration/modbus-write-integration-test.js
+++ b/test/integration/modbus-write-integration-test.js
@@ -113,8 +113,9 @@ const testFlowWriting = [
     commandDelay: '1',
     clientTimeout: '1000',
     reconnectOnTimeout: true,
-    reconnectTimeout: 200,
-    parallelUnitIdsAllowed: true
+    reconnectDelay: 200,
+    parallelUnitIdsAllowed: true,
+    connectionTimeout: 10000
   }
 ]
 

--- a/test/nodes/modbus-client-test.js
+++ b/test/nodes/modbus-client-test.js
@@ -88,8 +88,9 @@ const simpleReadWithClient = [
     unit_id: '1',
     commandDelay: '1',
     clientTimeout: '100',
-    reconnectTimeout: 200,
-    reconnectOnTimeout: true
+    reconnectDelay: 200,
+    reconnectOnTimeout: true,
+    connectionTimeout: 10000
   }
 ]
 
@@ -137,8 +138,9 @@ describe('Client node Testing', function () {
         unit_id: '1',
         commandDelay: '1',
         clientTimeout: '100',
-        reconnectTimeout: 200,
-        reconnectOnTimeout: true
+        reconnectDelay: 200,
+        reconnectOnTimeout: true,
+        connectionTimeout: 10000
       },
       {
         id: '384fb9f1.e96296',
@@ -189,8 +191,9 @@ describe('Client node Testing', function () {
         unit_id: '1',
         commandDelay: '1',
         clientTimeout: '100',
-        reconnectTimeout: 200,
-        reconnectOnTimeout: true
+        reconnectDelay: 200,
+        reconnectOnTimeout: true,
+        connectionTimeout: 10000
       },
       {
         id: '384fb9f1.e96296',
@@ -241,8 +244,9 @@ describe('Client node Testing', function () {
         unit_id: '1',
         commandDelay: '1',
         clientTimeout: '100',
-        reconnectTimeout: 200,
-        reconnectOnTimeout: true
+        reconnectDelay: 200,
+        reconnectOnTimeout: true,
+        connectionTimeout: 10000
       },
       {
         id: '384fb9f1.e96296',
@@ -293,8 +297,9 @@ describe('Client node Testing', function () {
         unit_id: '1',
         commandDelay: '1',
         clientTimeout: '100',
-        reconnectTimeout: 200,
-        reconnectOnTimeout: true
+        reconnectDelay: 200,
+        reconnectOnTimeout: true,
+        connectionTimeout: 10000
       },
       {
         id: '384fb9f1.e96296',
@@ -345,8 +350,9 @@ describe('Client node Testing', function () {
         unit_id: '1',
         commandDelay: '1',
         clientTimeout: '100',
-        reconnectTimeout: 200,
-        reconnectOnTimeout: true
+        reconnectDelay: 200,
+        reconnectOnTimeout: true,
+        connectionTimeout: 10000
       },
       {
         id: '384fb9f1.e96296',
@@ -397,8 +403,9 @@ describe('Client node Testing', function () {
         unit_id: '1',
         commandDelay: '1',
         clientTimeout: '100',
-        reconnectTimeout: 200,
-        reconnectOnTimeout: true
+        reconnectDelay: 200,
+        reconnectOnTimeout: true,
+        connectionTimeout: 10000
       },
       {
         id: '384fb9f1.e96296',
@@ -449,8 +456,9 @@ describe('Client node Testing', function () {
         unit_id: '1',
         commandDelay: '1',
         clientTimeout: '100',
-        reconnectTimeout: 200,
-        reconnectOnTimeout: true
+        reconnectDelay: 200,
+        reconnectOnTimeout: true,
+        connectionTimeout: 10000
       },
       {
         id: '384fb9f1.e96296',

--- a/test/nodes/modbus-flex-connector-test.js
+++ b/test/nodes/modbus-flex-connector-test.js
@@ -73,8 +73,9 @@ describe('Flex Connector node Testing', function () {
           unit_id: '1',
           commandDelay: '100',
           clientTimeout: '100',
-          reconnectTimeout: 200,
-          reconnectOnTimeout: true
+          reconnectDelay: 200,
+          reconnectOnTimeout: true,
+          connectionTimeout: 10000
         }
       ], function () {
         var modbusNode = helper.getNode('40ddaabb.fd44d4')
@@ -139,8 +140,9 @@ describe('Flex Connector node Testing', function () {
           unit_id: '1',
           commandDelay: '100',
           clientTimeout: '100',
-          reconnectTimeout: '200',
-          reconnectOnTimeout: true
+          reconnectDelay: '200',
+          reconnectOnTimeout: true,
+          connectionTimeout: 10000
         }
       ], function () {
         var modbusNode = helper.getNode('40ddaabb.fd44d4')
@@ -193,8 +195,9 @@ describe('Flex Connector node Testing', function () {
           unit_id: '1',
           commandDelay: '100',
           clientTimeout: '100',
-          reconnectTimeout: '200',
-          reconnectOnTimeout: true
+          reconnectDelay: '200',
+          reconnectOnTimeout: true,
+          connectionTimeout: 10000
         }
       ], function () {
         var modbusNode = helper.getNode('40ddaabb.fd44d4')

--- a/test/nodes/modbus-flex-getter-test.js
+++ b/test/nodes/modbus-flex-getter-test.js
@@ -98,7 +98,8 @@ var testFlexGetterFlowWithInject = [{
   unit_id: '1',
   commandDelay: '1',
   clientTimeout: '100',
-  reconnectTimeout: 200
+  reconnectDelay: 200,
+  connectionTimeout: 10000
 }
 ]
 
@@ -163,7 +164,8 @@ var testFlexGetterFlow = [{
   unit_id: '1',
   commandDelay: '1',
   clientTimeout: '100',
-  reconnectTimeout: 200
+  reconnectDelay: 200,
+  connectionTimeout: 10000
 }
 ]
 
@@ -273,7 +275,8 @@ describe('Flex Getter node Testing', function () {
         unit_id: '1',
         commandDelay: '1',
         clientTimeout: '100',
-        reconnectTimeout: 200
+        reconnectDelay: 200,
+        connectionTimeout: 10000
       }], function () {
         const modbusServer = helper.getNode('996023fe.ea04b')
         modbusServer.should.have.property('name', 'modbusServer')

--- a/test/nodes/modbus-flex-write-test.js
+++ b/test/nodes/modbus-flex-write-test.js
@@ -105,7 +105,8 @@ var testWriteParametersFlow = [
     unit_id: '1',
     commandDelay: '1',
     clientTimeout: '100',
-    reconnectTimeout: 200
+    reconnectDelay: 200,
+    connectionTimeout: 10000
   }
 ]
 
@@ -192,7 +193,8 @@ describe('Flex Write node Testing', function () {
           unit_id: '1',
           commandDelay: '1',
           clientTimeout: '100',
-          reconnectTimeout: 200
+          reconnectDelay: 200,
+          connectionTimeout: 10000
         }
       ], function () {
         const modbusFlexWrite = helper.getNode('c02b6d1.d419c1')
@@ -293,7 +295,8 @@ describe('Flex Write node Testing', function () {
           unit_id: '1',
           commandDelay: '1',
           clientTimeout: '100',
-          reconnectTimeout: 200
+          reconnectDelay: 200,
+          connectionTimeout: 10000
         }
       ], function () {
         const h1 = helper.getNode('h1')

--- a/test/nodes/modbus-getter-test.js
+++ b/test/nodes/modbus-getter-test.js
@@ -105,7 +105,8 @@ var testGetterFlowWithInject = [{
   unit_id: '1',
   commandDelay: '1',
   clientTimeout: '100',
-  reconnectTimeout: 200
+  reconnectDelay: 200,
+  connectionTimeout: 10000
 },
 {
   id: 'e0519b16.5fcdd',
@@ -184,7 +185,8 @@ var testGetterFlow = [{
   unit_id: '1',
   commandDelay: '1',
   clientTimeout: '100',
-  reconnectTimeout: 200
+  reconnectDelay: 200,
+  connectionTimeout: 10000
 },
 {
   id: 'e0519b16.5fcdd',
@@ -281,8 +283,9 @@ describe('Getter node Testing', function () {
         tcpPort: 8502,
         unit_id: 1,
         clientTimeout: 100,
-        reconnectTimeout: 200,
-        parallelUnitIdsAllowed: true
+        reconnectDelay: 200,
+        parallelUnitIdsAllowed: true,
+        connectionTimeout: 10000
       }], function () {
         const modbusServer = helper.getNode('996023fe.ea04b')
         modbusServer.should.have.property('name', 'modbusServer')
@@ -383,7 +386,8 @@ describe('Getter node Testing', function () {
         unit_id: '1',
         commandDelay: '1',
         clientTimeout: '100',
-        reconnectTimeout: 200
+        reconnectDelay: 200,
+        connectionTimeout: 10000
       }
       ], function () {
         const h1 = helper.getNode('h1')

--- a/test/nodes/modbus-queue-info-test.js
+++ b/test/nodes/modbus-queue-info-test.js
@@ -119,7 +119,8 @@ describe('Queue Info node Testing', function () {
           unit_id: '1',
           commandDelay: '1',
           clientTimeout: '100',
-          reconnectTimeout: 200
+          reconnectDelay: 200,
+          connectionTimeout: 10000
         }
       ], function () {
         const modbusServer = helper.getNode('389153e.cb648ac')
@@ -216,7 +217,8 @@ describe('Queue Info node Testing', function () {
         unit_id: '1',
         commandDelay: '1',
         clientTimeout: '100',
-        reconnectTimeout: 200
+        reconnectDelay: 200,
+        connectionTimeout: 10000
       }], function () {
         const h1 = helper.getNode('h1')
         h1.on('input', function (msg) {
@@ -308,7 +310,8 @@ describe('Queue Info node Testing', function () {
         unit_id: '1',
         commandDelay: '1',
         clientTimeout: '100',
-        reconnectTimeout: 200
+        reconnectDelay: 200,
+        connectionTimeout: 10000
       }], function () {
         const h1 = helper.getNode('h1')
         h1.on('input', function (msg) {
@@ -426,7 +429,8 @@ describe('Queue Info node Testing', function () {
         unit_id: '1',
         commandDelay: '1',
         clientTimeout: '100',
-        reconnectTimeout: 200
+        reconnectDelay: 200,
+        connectionTimeout: 10000
       }], function () {
         const h1 = helper.getNode('h1')
         let countMsg = 0

--- a/test/nodes/modbus-read-test.js
+++ b/test/nodes/modbus-read-test.js
@@ -88,7 +88,8 @@ const readMsgFlow = [
     unit_id: '1',
     commandDelay: '1',
     clientTimeout: '100',
-    reconnectTimeout: 200
+    reconnectDelay: 200,
+    connectionTimeout: 10000
   }
 ]
 
@@ -215,7 +216,8 @@ describe('Read node Testing', function () {
         unit_id: '1',
         commandDelay: '1',
         clientTimeout: '100',
-        reconnectTimeout: 200
+        reconnectDelay: 200,
+        connectionTimeout: 10000
       }
       ], function () {
         var modbusServer = helper.getNode('e54529b9.952ea8')
@@ -337,7 +339,8 @@ describe('Read node Testing', function () {
           unit_id: '1',
           commandDelay: '1',
           clientTimeout: '100',
-          reconnectTimeout: 200
+          reconnectDelay: 200,
+          connectionTimeout: 10000
         },
         {
           id: 'e0519b16.5fcdd',
@@ -433,7 +436,8 @@ describe('Read node Testing', function () {
           unit_id: '1',
           commandDelay: '1',
           clientTimeout: '100',
-          reconnectTimeout: 200
+          reconnectDelay: 200,
+          connectionTimeout: 10000
         },
         {
           id: 'e0519b16.5fcdd',
@@ -536,7 +540,8 @@ describe('Read node Testing', function () {
         unit_id: '1',
         commandDelay: '1',
         clientTimeout: '100',
-        reconnectTimeout: 200
+        reconnectDelay: 200,
+        connectionTimeout: 10000
       }
       ], function () {
         helper.request().post('/modbus/read/inject/8ecaae3e.4b8928').expect(200).end(done)

--- a/test/nodes/modbus-response-filter-test.js
+++ b/test/nodes/modbus-response-filter-test.js
@@ -283,7 +283,8 @@ describe('Response Filter node Testing', function () {
           unit_id: '1',
           commandDelay: '1',
           clientTimeout: '100',
-          reconnectTimeout: 200
+          reconnectDelay: 200,
+          connectionTimeout: 10000
         },
         {
           id: '7417947e.da6c3c',

--- a/test/nodes/modbus-write-test.js
+++ b/test/nodes/modbus-write-test.js
@@ -83,7 +83,8 @@ var testSimpleWriteParametersFlow = [{
   unit_id: '1',
   commandDelay: '1',
   clientTimeout: '100',
-  reconnectTimeout: 200
+  reconnectDelay: 200,
+  connectionTimeout: 10000
 }
 ]
 
@@ -174,10 +175,11 @@ describe('Write node Testing', function () {
         tcpPort: 8502,
         unit_id: 1,
         clientTimeout: 100,
-        reconnectTimeout: 200,
+        reconnectDelay: 200,
         bufferCommands: true,
         stateLogEnabled: false,
-        parallelUnitIdsAllowed: true
+        parallelUnitIdsAllowed: true,
+        connectionTimeout: 10000
       }], function () {
         var inject = helper.getNode('67dded7e.025904')
         inject.should.have.property('name', 'injectTrue')
@@ -295,7 +297,8 @@ describe('Write node Testing', function () {
         unit_id: '1',
         commandDelay: '1',
         clientTimeout: '100',
-        reconnectTimeout: 200
+        reconnectDelay: 200,
+        connectionTimeout: 10000
       }
       ], function () {
         const modbusWrite = helper.getNode('1ed908da.427ecf')


### PR DESCRIPTION
Node.js v14 changed the way it returns socket error codes. 
On a connection timeout, `err.errno` now contains the code -110 instead of the string ETIMEDOUT it used to have. 
**This actually causes the state machine to get stuck and never try to reconnect. Once the connection is lost for a long enough time, you have to restart the module to regain communication again.** See #236 

From Node.js v14 docs:
>The error.errno property is a **negative number** which corresponds to the error code defined in libuv Error handling.
>The error.code property is a **string** representing the error code.

Looking back at Node.js v12 docs:
>The error.errno property is a **number or a string**.

I think the right way would be to use `error.code` in this case, since we are expecting strings. But for the sake of compatibility, leaving a check for `errno` as well is a good idea, especially since the underlaying Modbus library is generating some errors by populating just the `errno` without using `code`.

No need to add this extra check to the `modbusErrorHandling` function since this one is only called during the Modbus library errors and not when socket errors occur (controlled by Node.js itself)