### PR TITLE
Add check for err.code on tcp error handling

### DIFF
--- a/src/modbus-client.js
+++ b/src/modbus-client.js
@@ -412,7 +412,8 @@ module.exports = function (RED) {
         coreModbusClient.modbusSerialDebug('modbusTcpErrorHandling:' + JSON.stringify(err))
       }
 
-      if (err.errno && coreModbusClient.networkErrors.includes(err.errno)) {
+      if ((err.errno && coreModbusClient.networkErrors.includes(err.errno)) ||
+      (err.code && coreModbusClient.networkErrors.includes(err.code))) {
         node.stateService.send('BREAK')
       }
     }


### PR DESCRIPTION
Node.js v14 changed the way it returns socket error codes. 
On a connection timeout, `err.errno` now contains the code -110 instead of the string ETIMEDOUT it used to have. 
**This actually causes the state machine to get stuck and never try to reconnect. Once the connection is lost for a long enough time, you have to restart the module to regain communication again.** See #236 

From Node.js v14 docs:
>The error.errno property is a **negative number** which corresponds to the error code defined in libuv Error handling.
>The error.code property is a **string** representing the error code.

Looking back at Node.js v12 docs:
>The error.errno property is a **number or a string**.

I think the right way would be to use `error.code` in this case, since we are expecting strings. But for the sake of compatibility, leaving a check for `errno` as well is a good idea, especially since the underlaying Modbus library is generating some errors by populating just the `errno` without using `code`.

No need to add this extra check to the `modbusErrorHandling` function since this one is only called during the Modbus library errors and not when socket errors occur (controlled by Node.js itself)