### PR TITLE
fix(package): remove deps on sh and node in path

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "docs",
     "examples",
     "modbus",
-    "supporter.js",
     "extras/argumentMaps/defaults",
     "extras/argumentMaps/ArgumentMaps.md",
     ".npmrc"
@@ -86,7 +85,6 @@
     "release:beta": "standard-version --prerelease beta",
     "release:alpha": "standard-version --prerelease alpha",
     "rewrite-changelog": "gulp changelog",
-    "postinstall": "node ./supporter.js",
     "clean": "gulp clean",
     "dev-link": "npm i && npm run build && npm link",
     "dev-unlink": "npm unlink node-red-contrib-modbus -g",

--- a/supporter.js
+++ b/supporter.js
@@ -1,3 +1,0 @@
-const message =
-  '\u001b[96m\u001b[1mThank you for using our contribution!\u001b[96m\u001b[1m\n\u001b[0m\u001b[96mIf you rely on this package, please consider supporting our open source work:\u001b[22m\u001b[39m\n> \u001b[94mhttps://bianco-royal.space/supporter/\u001b[0m\n\n'
-console.log(message)


### PR DESCRIPTION
**Which issues are addressed by this Pull Request?**

The package requires `sh` and `node` to be available in the path during installation to display the message in [supporter.js](https://github.com/BiancoRoyal/node-red-contrib-modbus/blob/V5.28.0/supporter.js). This might not be given in restricted environments (for example [NixOS](https://github.com/NixOS/nixpkgs/issues/280767)). Most users will not see the message anyway, I assume.

**What does this Pull Request change?**

Drop `supporter.js` and its `postInstall` invocation.

**Does this Pull Request introduce any potentially breaking changes?**

No.