### PR TITLE
fix(modbus-client): respect parallelUnitIdsAllowed in queue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-modbus",
-  "version": "5.40.0",
+  "version": "5.41.0",
   "private": false,
   "description": "The all in one Modbus TCP and Serial contribution long term supported package for Node-RED.",
   "dependencies": {

--- a/src/modbus-client.js
+++ b/src/modbus-client.js
@@ -221,11 +221,18 @@ module.exports = function (RED) {
 
       if (state.matches('queueing')) {
         if (node.clienttype === 'tcp') {
-          node.stateService.send('SEND')
+          if (!node.parallelUnitIdsAllowed) {
+            if (node.serialSendingAllowed) {
+              coreModbusQueue.queueSerialLockCommand(node);
+              node.stateService.send('SEND');
+            }
+          } else {
+            node.stateService.send('SEND');
+          }
         } else {
           if (node.serialSendingAllowed) {
-            coreModbusQueue.queueSerialLockCommand(node)
-            node.stateService.send('SEND')
+            coreModbusQueue.queueSerialLockCommand(node);
+            node.stateService.send('SEND');
           }
         }
       }


### PR DESCRIPTION

**Which issues are addressed by this Pull Request?**

#472 

**What does this Pull Request change?**

Uses the same technique that is used on serial connections to make sure that modbus requests go out in serial order and not parallel for modbus-tcp connections when `parallelUnitIdsAllowed` is disabled.

**Does this Pull Request introduce any potentially breaking changes?**

I don't think so