### PR TITLE
enchance: Use `node.client.connectUDP` to support UDP type.

### DIFF
--- a/src/modbus-client.html
+++ b/src/modbus-client.html
@@ -256,6 +256,7 @@
                         <option value="TCP-RTU-BUFFERED">RTU-BUFFERED</option>
                         <option value="TELNET">TELNET</option>
                         <option value="C701">C701</option>
+                        <option value="UDP">UDP</option>
                     </select>
                 </div>
             </div>

--- a/src/modbus-client.js
+++ b/src/modbus-client.js
@@ -372,6 +372,17 @@ module.exports = function (RED) {
                     return false
                   })
                 break
+              case 'UDP':
+                  verboseLog('UDP port')
+                  node.client.connectUDP(node.tcpHost, {
+                    port: node.tcpPort,
+                    autoOpen: true
+                  }).then(node.setTCPConnectionOptions)
+                    .catch((err) => {
+                      node.modbusTcpErrorHandling(err)
+                      return false
+                    })
+                  break
               default:
                 verboseLog('TCP port')
                 node.client.connectTCP(node.tcpHost, {


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

Please make sure you've read our contributing guidelines (https://github.com/BiancoRoyal/node-red-contrib-modbus/blob/develop/.github/CONTRIBUTING.md)

-->

**Which issues are addressed by this Pull Request?**
Supporting UDP... Ref: https://github.com/BiancoRoyal/node-red-contrib-modbus/issues/478

**What does this Pull Request change?**
- tcpType add "UDP" type.
- Use `node.client.connectUDP(...)` to connect.

**Does this Pull Request introduce any potentially breaking changes?**
<!--
If you have made any changes to the message format sent between units or to a node's configuration,
please include bullet points of what changed and what a current user needs to update to keep the same
behavior they have with the previous version.
-->
I don't think so.
