### PR TITLE
Fix: Ensure emptyMsgOnFail is triggered on all errors

### DIFF
--- a/src/modbus-flex-getter.js
+++ b/src/modbus-flex-getter.js
@@ -77,7 +77,7 @@ module.exports = function (RED) {
       node.internalDebugLog(err.message)
       const origMsg = mbCore.getOriginalMessage(node.bufferMessageList, msg)
       node.errorProtocolMsg(err, origMsg)
-      mbBasics.sendEmptyMsgOnFail(node, err, msg)
+      mbBasics.sendEmptyMsgOnFail(node, err, origMsg)
       mbBasics.setModbusError(node, modbusClient, err, origMsg)
       node.emit('modbusFlexGetterNodeError')
     }


### PR DESCRIPTION
**Which issues are addressed by this Pull Request?**
This Pull Request addresses issue #517.

**What does this Pull Request change?**
The change corrects the behavior of the `emptyMsgOnFail` option in the `modbus-flex-getter` node. Previously, when an error occurred during message handling, the function `mbBasics.sendEmptyMsgOnFail` was being called with an incorrect message reference (`msg`). This prevented the node from correctly sending an empty message on failure.

The fix consists of changing the call from:
```javascript
mbBasics.sendEmptyMsgOnFail(node, err, msg)
```
To:
```javascript
mbBasics.sendEmptyMsgOnFail(node, err, origMsg)
```

This ensures the original input message is passed, restoring the expected behavior of emitting an empty message when a failure occurs.


**Does this Pull Request introduce any potentially breaking changes?**
No breaking changes are introduced. This is a bugfix that restores previously expected functionality for users relying on `emptyMsgOnFail`. Existing configurations and integrations will continue to work as before.
