### PR TITLE
Changing the bufferFactor so the correct address gets written to

### DIFF
--- a/src/core/modbus-server-core.js
+++ b/src/core/modbus-server-core.js
@@ -14,7 +14,7 @@ const _ = require('underscore')
 var de = de || { biancoroyal: { modbus: { core: { server: { } } } } } // eslint-disable-line no-use-before-define
 de.biancoroyal.modbus.core.server.internalDebug = de.biancoroyal.modbus.core.server.internalDebug || require('debug')('contribModbus:core:server') // eslint-disable-line no-use-before-define
 
-de.biancoroyal.modbus.core.server.bufferFactor = 8
+de.biancoroyal.modbus.core.server.bufferFactor = 2
 de.biancoroyal.modbus.core.server.memoryTypes = ['holding', 'coils', 'input', 'discrete']
 de.biancoroyal.modbus.core.server.memoryUint16Types = ['holding', 'input']
 de.biancoroyal.modbus.core.server.memoryUint8Types = ['coils', 'discrete']


### PR DESCRIPTION
When writing to address 5, you need to write to buffer 10. Not 40. 

address 2 * 8 bufferFactor = writing to address 4. what is not correct

<!--
Thank you for contributing to this project!

Please make sure you've read our contributing guidelines (https://github.com/BiancoRoyal/node-red-contrib-modbus/blob/develop/.github/CONTRIBUTING.md)

-->

**Which issues are addressed by this Pull Request?**
Incorrect writing addresses in the modbus Server

**What does this Pull Request change?**
Set buffer factor to 2, from 8.

**Does this Pull Request introduce any potentially breaking changes?**
<!--
If you have made any changes to the message format sent between units or to a node's configuration,
please include bullet points of what changed and what a current user needs to update to keep the same
behavior they have with the previous version.
-->
