### PR TITLE
fix: improve JSON error handling and error logging

### DIFF
--- a/src/core/modbus-server-core.js
+++ b/src/core/modbus-server-core.js
@@ -166,7 +166,7 @@ de.biancoroyal.modbus.core.server.writeToServerMemory = function (node, msg) {
     }
   } catch (err) {
     msg.error = err
-    node.error(err)
+    node.error(err.message || err.toString() || 'Unknown error', { error: err })
   }
 }
 
@@ -178,7 +178,7 @@ de.biancoroyal.modbus.core.server.writeToFlexServerMemory = function (node, msg)
     }
   } catch (err) {
     msg.error = err
-    node.error(err)
+    node.error(err.message || err.toString() || 'Unknown error', { error: err })
   }
 }
 

--- a/src/modbus-client.js
+++ b/src/modbus-client.js
@@ -489,11 +489,7 @@ module.exports = function (RED) {
 
     node.modbusErrorHandling = function (err) {
       coreModbusQueue.queueSerialUnlockCommand(node)
-      if (err.message) {
-        coreModbusClient.modbusSerialDebug('modbusErrorHandling:' + err.message)
-      } else {
-        coreModbusClient.modbusSerialDebug('modbusErrorHandling:' + JSON.stringify(err))
-      }
+      coreModbusClient.modbusSerialDebug('modbusErrorHandling:' + (err.message || err.toString() || 'Unknown error'))
       if (err.errno && coreModbusClient.networkErrors.includes(err.errno)) {
         node.stateService.send('FAILURE')
       }
@@ -501,16 +497,13 @@ module.exports = function (RED) {
 
     node.modbusTcpErrorHandling = function (err) {
       coreModbusQueue.queueSerialUnlockCommand(node)
+      const errorMessage = err.message || err.toString() || 'Unknown error'
       if (node.showErrors) {
-        node.error(err)
+        node.error(errorMessage, { error: err })
       }
 
       if (node.failureLogEnabled) {
-        if (err.message) {
-          coreModbusClient.modbusSerialDebug('modbusTcpErrorHandling:' + err.message)
-        } else {
-          coreModbusClient.modbusSerialDebug('modbusTcpErrorHandling:' + JSON.stringify(err))
-        }
+        coreModbusClient.modbusSerialDebug('modbusTcpErrorHandling:' + errorMessage)
       }
 
       if ((err.errno && coreModbusClient.networkErrors.includes(err.errno)) ||
@@ -521,16 +514,13 @@ module.exports = function (RED) {
 
     node.modbusSerialErrorHandling = function (err) {
       coreModbusQueue.queueSerialUnlockCommand(node)
+      const errorMessage = err.message || err.toString() || 'Unknown error'
       if (node.showErrors) {
-        node.error(err)
+        node.error(errorMessage, { error: err })
       }
 
       if (node.failureLogEnabled) {
-        if (err.message) {
-          coreModbusClient.modbusSerialDebug('modbusSerialErrorHandling:' + err.message)
-        } else {
-          coreModbusClient.modbusSerialDebug('modbusSerialErrorHandling:' + JSON.stringify(err))
-        }
+        coreModbusClient.modbusSerialDebug('modbusSerialErrorHandling:' + errorMessage)
       }
 
       node.stateService.send('BREAK')
@@ -752,8 +742,9 @@ module.exports = function (RED) {
         }
       } catch (err) {
         /* istanbul ignore next */
-        verboseWarn(err.message + ' on de-register node ' + clientUserNodeId)
-        node.error(err)
+        const errorMessage = err.message || err.toString() || 'Unknown error'
+        verboseWarn(errorMessage + ' on de-register node ' + clientUserNodeId)
+        node.error(errorMessage, { error: err })
         done()
       }
     }

--- a/src/modbus-flex-getter.js
+++ b/src/modbus-flex-getter.js
@@ -85,7 +85,12 @@ module.exports = function (RED) {
 
     node.prepareMsg = function (msg) {
       if (typeof msg.payload === 'string') {
-        msg.payload = JSON.parse(msg.payload)
+        try {
+          msg.payload = JSON.parse(msg.payload)
+        } catch (err) {
+          node.error('Invalid JSON in payload: ' + err.message, msg)
+          return null
+        }
       }
 
       msg.payload.fc = parseInt(msg.payload.fc) || 3
@@ -219,7 +224,9 @@ module.exports = function (RED) {
       const origMsgInput = Object.assign({}, msg)
       try {
         const inputMsg = node.prepareMsg(origMsgInput)
-        if (node.isValidModbusMsg(inputMsg)) {
+        if (!inputMsg) {
+          mbBasics.sendEmptyMsgOnFail(node, new Error('Invalid JSON in payload'), origMsgInput)
+        } else if (node.isValidModbusMsg(inputMsg)) {
           const newMsg = node.buildNewMessageObject(node, inputMsg)
           node.bufferMessageList.set(newMsg.messageId, mbBasics.buildNewMessage(node.keepMsgProperties, inputMsg, newMsg))
           modbusClient.emit('readModbus', newMsg, node.onModbusReadDone, node.onModbusReadError)

--- a/src/modbus-flex-sequencer.js
+++ b/src/modbus-flex-sequencer.js
@@ -86,8 +86,12 @@ module.exports = function (RED) {
 
     node.prepareMsg = (msg) => {
       if (typeof msg === 'string') {
-        // NOTE: The operation can fail!
-        msg = JSON.parse(msg)
+        try {
+          msg = JSON.parse(msg)
+        } catch (err) {
+          node.error('Invalid JSON in message: ' + err.message)
+          return null
+        }
       }
 
       switch (msg.fc) {
@@ -220,7 +224,9 @@ module.exports = function (RED) {
       try {
         sequences.forEach(msg => {
           const inputMsg = node.prepareMsg(msg)
-          if (node.isValidModbusMsg(inputMsg)) {
+          if (!inputMsg) {
+            mbBasics.sendEmptyMsgOnFail(node, new Error('Invalid JSON in sequence message'), origMsgInput)
+          } else if (node.isValidModbusMsg(inputMsg)) {
             const newMsg = node.buildNewMessageObject(node, inputMsg)
             node.bufferMessageList.set(newMsg.messageId, mbBasics.buildNewMessage(node.keepMsgProperties, inputMsg, newMsg))
             modbusClient.emit('readModbus', newMsg, node.onModbusReadDone, node.onModbusReadError)

--- a/src/modbus-flex-write.js
+++ b/src/modbus-flex-write.js
@@ -76,7 +76,12 @@ module.exports = function (RED) {
 
     node.prepareMsg = function (msg) {
       if (typeof msg.payload === 'string') {
-        msg.payload = JSON.parse(msg.payload)
+        try {
+          msg.payload = JSON.parse(msg.payload)
+        } catch (err) {
+          node.error('Invalid JSON in payload: ' + err.message, msg)
+          return null
+        }
       }
 
       msg.payload.fc = parseInt(msg.payload.fc)
@@ -124,7 +129,12 @@ module.exports = function (RED) {
           msg.payload.value = (msg.payload.value === 'true')
         } else {
           if (msg.payload.value.indexOf(',') > -1) {
-            msg.payload.value = JSON.parse(msg.payload.value)
+            try {
+              msg.payload.value = JSON.parse(msg.payload.value)
+            } catch (err) {
+              node.error('Invalid JSON in payload.value: ' + err.message, msg)
+              return null
+            }
           }
         }
       }
@@ -207,11 +217,17 @@ module.exports = function (RED) {
       const origMsgInput = Object.assign({}, msg)
       try {
         const inputMsg = node.prepareMsg(origMsgInput)
-        if (node.isValidModbusMsg(inputMsg)) {
+        if (!inputMsg) {
+          mbBasics.sendEmptyMsgOnFail(node, new Error('Invalid JSON in payload'), origMsgInput)
+        } else if (node.isValidModbusMsg(inputMsg)) {
           const httpMsg = node.setMsgPayloadFromHTTPRequests(inputMsg)
-          const newMsg = node.buildNewMessageObject(node, httpMsg)
-          node.bufferMessageList.set(newMsg.messageId, mbBasics.buildNewMessage(node.keepMsgProperties, httpMsg, newMsg))
-          modbusClient.emit('writeModbus', newMsg, node.onModbusWriteDone, node.onModbusWriteError)
+          if (!httpMsg) {
+            mbBasics.sendEmptyMsgOnFail(node, new Error('Invalid JSON in payload.value'), origMsgInput)
+          } else {
+            const newMsg = node.buildNewMessageObject(node, httpMsg)
+            node.bufferMessageList.set(newMsg.messageId, mbBasics.buildNewMessage(node.keepMsgProperties, httpMsg, newMsg))
+            modbusClient.emit('writeModbus', newMsg, node.onModbusWriteDone, node.onModbusWriteError)
+          }
         }
       } catch (err) {
         node.errorProtocolMsg(err, origMsgInput)

--- a/src/modbus-server.js
+++ b/src/modbus-server.js
@@ -102,9 +102,10 @@ module.exports = function (RED) {
     }
 
     node.netServer.on('error', function (err) {
-      internalDebugLog(err.message)
+      const errorMessage = err.message || err.toString() || 'Unknown error'
+      internalDebugLog(errorMessage)
       if (node.showErrors) {
-        node.error(err)
+        node.error(errorMessage, { error: err })
       }
       mbBasics.setNodeStatusTo('error', node)
     })

--- a/src/modbus-write.js
+++ b/src/modbus-write.js
@@ -89,7 +89,12 @@ module.exports = function (RED) {
           msg.payload.value = (msg.payload.value === 'true')
         } else {
           if (msg.payload.value.indexOf(',') > -1) {
-            msg.payload.value = JSON.parse(msg.payload.value)
+            try {
+              msg.payload.value = JSON.parse(msg.payload.value)
+            } catch (err) {
+              node.error('Invalid JSON in payload.value: ' + err.message, msg)
+              return null
+            }
           }
         }
       }
@@ -171,6 +176,10 @@ module.exports = function (RED) {
       const origMsgInput = Object.assign({}, msg)
       try {
         const httpMsg = node.setMsgPayloadFromHTTPRequests(origMsgInput)
+        if (!httpMsg) {
+          mbBasics.sendEmptyMsgOnFail(node, new Error('Invalid JSON in payload.value'), origMsgInput)
+          return
+        }
         const newMsg = node.buildNewMessageObject(node, httpMsg)
         node.bufferMessageList.set(newMsg.messageId, mbBasics.buildNewMessage(node.keepMsgProperties, httpMsg, newMsg))
         modbusClient.emit('writeModbus', newMsg, node.onModbusWriteDone, node.onModbusWriteError)


### PR DESCRIPTION
## Summary

- Wrap JSON.parse calls in try-catch blocks to prevent uncaught exceptions that could crash Node-RED when invalid JSON is received
- Fix error logging that produced empty `[error] {}` output by replacing `JSON.stringify(err)` with proper error message extraction

## Changes

### 1. JSON.parse error handling

| File | Function | Issue |
|------|----------|-------|
| `modbus-flex-getter.js` | `prepareMsg()` | JSON.parse without try-catch |
| `modbus-flex-write.js` | `prepareMsg()` | JSON.parse without try-catch |
| `modbus-flex-write.js` | `setMsgPayloadFromHTTPRequests()` | JSON.parse without try-catch |
| `modbus-write.js` | `setMsgPayloadFromHTTPRequests()` | JSON.parse without try-catch |
| `modbus-flex-sequencer.js` | `prepareMsg()` | JSON.parse without try-catch |

### 2. Error logging fix

| File | Function | Issue |
|------|----------|-------|
| `modbus-client.js` | `modbusErrorHandling()` | `JSON.stringify(err)` produces `{}` |
| `modbus-client.js` | `modbusTcpErrorHandling()` | `JSON.stringify(err)` + `node.error(err)` |
| `modbus-client.js` | `modbusSerialErrorHandling()` | `JSON.stringify(err)` + `node.error(err)` |
| `modbus-client.js` | `onClientUserNodeUnRegister()` | `node.error(err)` |
| `modbus-server.js` | `netServer.on('error')` | `node.error(err)` |
| `modbus-server-core.js` | `writeToServerMemory()` | `node.error(err)` |
| `modbus-server-core.js` | `writeToFlexServerMemory()` | `node.error(err)` |

## Fix patterns

**JSON.parse:**
- Wraps in try-catch, reports error via `node.error()`, returns null on failure

**Error logging:**
- Replaced `JSON.stringify(err)` and `node.error(err)` with:
```javascript
const errorMessage = err.message || err.toString() || 'Unknown error'
node.error(errorMessage, { error: err })
```

## Impact

- **Valid JSON input**: No change in behavior
- **Invalid JSON input**: Graceful error instead of Node-RED crash
- **Error logging**: Human-readable messages instead of empty `{}`