### PR TITLE
fix(server): destroy client sockets on close so the node can shut down

### DIFF
--- a/src/modbus-server.js
+++ b/src/modbus-server.js
@@ -46,6 +46,7 @@ module.exports = function (RED) {
 
     node.netServer = null
     node.modbusServer = null
+    node.clientSockets = new Set()
 
     mbBasics.setNodeStatusTo('initialized', node)
 
@@ -76,6 +77,10 @@ module.exports = function (RED) {
 
         // NOTE(Kay): Get the underlying socket of the client connection
         const socket = client.socket
+        node.clientSockets.add(socket)
+        socket.on('close', function () {
+          node.clientSockets.delete(socket)
+        })
         // NOTE(Kay): This event listener is making sure that node-RED does not crash, as jsmodbus isn't handling
         //           the error internally we need to handle the exception here!
         socket.on('error', function (err) {
@@ -139,6 +144,9 @@ module.exports = function (RED) {
       mbBasics.setNodeStatusTo('closed', node)
 
       if (node.netServer) {
+        node.clientSockets.forEach((socket) => { socket.destroy() })
+        node.clientSockets.clear()
+
         node.netServer.close(() => {
           internalDebugLog('Modbus Server closed')
           done()

--- a/test/units/modbus-server-test.js
+++ b/test/units/modbus-server-test.js
@@ -15,6 +15,7 @@ const globalConfig = require('@node-red/nodes/core/common/91-global-config')
 const injectNode = require('@node-red/nodes/core/common/20-inject.js')
 const serverNode = require('../../src/modbus-server.js')
 const testServerNodes = [injectNode, functionNode, globalConfig, serverNode]
+const net = require('net')
 const chai = require('chai')
 const expect = chai.expect
 const sinon = require('sinon')
@@ -46,6 +47,41 @@ describe('Server node Testing', function () {
   })
 
   describe('Node', function () {
+    it('should complete close while a client is connected', function (done) {
+      this.timeout(6000)
+      const flow = Array.from(testFlows.testServerConfig)
+
+      getPort().then((port) => {
+        flow[0].serverPort = port
+
+        helper.load(testServerNodes, flow, function () {
+          const modbusServer = helper.getNode('249922d5ac72b8cd')
+          const client = net.createConnection({ host: '127.0.0.1', port })
+          client.on('error', function () {})
+
+          client.on('connect', function () {
+            // give the server time to accept the connection, otherwise
+            // net.Server has no established connection to wait for on close
+            setTimeout(function () {
+              let settled = false
+              const finish = (err) => {
+                if (settled) { return }
+                settled = true
+                clearTimeout(timer)
+                client.destroy()
+                done(err)
+              }
+              const timer = setTimeout(() => {
+                finish(new Error('close() did not complete while a client was connected'))
+              }, 3000)
+
+              Promise.resolve(modbusServer.close()).then(() => finish()).catch(finish)
+            }, 300)
+          })
+        })
+      })
+    })
+
     it('should send message when valid message and output not disabled', function (done) {
       const flow = Array.from(testFlows.testServerConfig)
 


### PR DESCRIPTION
### Problem

`net.Server#close()` stops accepting new connections but its callback only fires once all
established connections have ended. The Modbus Server node closes the listener without
touching those connections, so when the node is restarted by a deploy while a client is
connected:

- the `close()` callback never runs, `done()` is never called, and Node-RED reports
  `Error stopping node: Close timed out`;
- the client sockets are never destroyed. The client keeps an open socket that nobody
  answers and, because no `FIN` is sent, it cannot detect the disconnect. A real PLC then
  stops working until it is power-cycled or the Node-RED process is restarted.

New connections to the same port are served normally, which makes this look like a
client-side problem while it is actually a leftover socket.

### Change

- Track the sockets of established client connections in `node.clientSockets`.
- Remove a socket from the set when it closes.
- Destroy the remaining sockets at the beginning of the `close` handler, before calling
  `netServer.close()`.

This lets `close()` complete immediately and makes clients see a proper disconnect, so
they reconnect on their own.

### Notes

- Behaviour while running is unchanged; only the shutdown path is touched.
- The `connection` handler already had the socket at hand (`const socket = client.socket`),
  so the tracking is two lines.
- No API or configuration change.

### Test

Added a unit test that connects a plain TCP client, waits for the server to accept it and
then asserts that `node.close()` completes. It fails on master with

```
1) Server node Testing Node should complete close while a client is connected:
   Error: close() did not complete while a client was connected
```

and passes with this change. The existing server tests are unaffected (12 passing before,
13 passing after).

Note: the test needs a short delay after the client's `connect` event. Calling
`close()` immediately can pass even on master, because the server has not accepted the
connection yet and therefore has nothing to wait for.

### How to verify manually

1. Modbus Server node on port `5502`, deploy.
2. `node -e "require('net').createConnection({ host: '127.0.0.1', port: 5502 })"` and leave it running.
3. Change the node's name and deploy again.

Before: `Error stopping node: Close timed out` and the socket stays open.
After: the deploy completes without the error and the socket is closed.
